### PR TITLE
Replace random_shuffle with shuffle

### DIFF
--- a/ch2/lineards/array_algorithms.cpp
+++ b/ch2/lineards/array_algorithms.cpp
@@ -36,7 +36,7 @@ int main() {
   printf("\n");
   printf("==================\n");
 
-  random_shuffle(v.begin(), v.end());            // shuffle the content
+  shuffle(v.begin(), v.end(), default_random_engine()); // shuffle the content
   for (auto &val : v)
     printf("%d ", val);
   printf("\n");


### PR DESCRIPTION
`random_shuffle` is deprecated in c++14 and removed in c++17 (https://en.cppreference.com/w/cpp/algorithm/random_shuffle). `shuffle` is added in c++11 to provide the same functionality.

If random seed is desired, replace `default_random_engine()` with `default_random_engine(random_device()())`.