### PR TITLE
Assign value for Enum

### DIFF
--- a/ch3/greedy/ballotboxes_UVa12390_bsta.py
+++ b/ch3/greedy/ballotboxes_UVa12390_bsta.py
@@ -1,0 +1,41 @@
+import sys
+
+def main():
+    inputs = sys.stdin.read().splitlines()
+    ln = 0
+    while True:
+        N,B = map(int, inputs[ln].split())
+        if N == -1 and B == -1: break
+        ln += 1
+        
+        A = []
+        for _ in range(N):
+            A.append(int(inputs[ln]))
+            ln += 1
+        ln += 1
+
+        A = tuple(A)
+
+        L = 1
+        R = max(A)
+        ans = R
+
+        # is x a feasible answer?
+        def can(x):
+          need = 0
+          for a in A:
+            need += (a + x - 1) // x
+          return need <= B
+
+        # binary search the answer
+        while L <= R:
+          m = (L + R) // 2
+          if can(m):
+            ans = m
+            R = m - 1
+          else:
+            L = m + 1
+
+        print(ans)
+
+main()

--- a/ch4/traversal/UVa11838.cpp
+++ b/ch4/traversal/UVa11838.cpp
@@ -8,7 +8,7 @@ typedef pair<int, int> ii;
 typedef vector<int> vi;
 typedef vector<ii> vii;
 
-enum { UNVISITED };
+enum { UNVISITED = -1 };
 
 int dfsNumberCounter, numSCC;
 vector<vii> AL, AL_T;

--- a/ch4/traversal/articulation.cpp
+++ b/ch4/traversal/articulation.cpp
@@ -5,7 +5,7 @@ typedef pair<int, int> ii;
 typedef vector<ii> vii;
 typedef vector<int> vi;
 
-enum { UNVISITED };                              // basic flag
+enum { UNVISITED = -1 };                              // basic flag
 
 // these variables have to be global to be easily accessible by our recursion (other ways exist)
 vector<vii> AL;

--- a/ch4/traversal/articulation.py
+++ b/ch4/traversal/articulation.py
@@ -1,0 +1,77 @@
+import sys
+from enum import Enum
+
+class flag(Enum):
+  UNVISITED = -1
+
+AL = []
+dfs_num = []
+dfs_low = []
+dfs_parent = []
+articulation_vertex = []
+dfsNumberCounter = 0
+dfsRoot = 0
+rootChildren = 0
+
+
+def articulationPointAndBridge(u):
+  global AL
+  global dfs_num, dfs_parent, dfs_low, articulation_vertex
+  global dfsNumberCounter, dfsRoot, rootChildren
+
+  dfs_low[u] = dfs_num[u] = dfsNumberCounter
+  dfsNumberCounter += 1
+  for (v, w) in AL[u]:
+    if dfs_num[v] == flag.UNVISITED.value:
+      dfs_parent[v] = u
+      if u == dfsRoot:
+        rootChildren += 1
+
+      articulationPointAndBridge(v)
+
+      if dfs_low[v] >= dfs_num[u]:
+        articulation_vertex[u] = True
+      if dfs_low[v] > dfs_num[u]:
+        print(' Edge (%d, %d) is a bridge' % (u, v))
+      dfs_low[u] = min(dfs_low[u], dfs_low[v])
+    elif v != dfs_parent[u]:
+      dfs_low[u] = min(dfs_low[u], dfs_num[v])
+
+
+def main():
+  global AL
+  global dfs_num, dfs_parent, dfs_low, articulation_vertex
+  global dfsNumberCounter, dfsRoot, rootChildren
+
+  fp = open('articulation_in.txt', 'r')
+
+  V = int(fp.readline().strip())
+  AL = [[] for _ in range(V)]
+  for u in range(V):
+    tkn = list(map(int, fp.readline().strip().split()))
+    k = tkn[0]
+    for i in range(k):
+      v, w = tkn[2*i+1], tkn[2*i+2]
+      AL[u].append((v, w))
+
+  print('Articulation Points & Bridges (the input graph must be UNDIRECTED)')
+  dfs_num = [flag.UNVISITED.value] * V
+  dfs_low = [0] * V
+  dfs_parent = [-1] * V
+  articulation_vertex = [False] * V
+  dfsNumberCounter = 0
+  print('Bridges:')
+  for u in range(V):
+    if dfs_num[u] == flag.UNVISITED.value:
+      dfsRoot = u
+      rootChildren = 0
+      articulationPointAndBridge(u)
+      articulation_vertex[dfsRoot] = (rootChildren > 1)
+
+  print('Articulation Points:')
+  for u in range(V):
+    if articulation_vertex[u]:
+      print(' Vertex %d' % u)
+
+
+main()

--- a/ch4/traversal/cyclecheck.cpp
+++ b/ch4/traversal/cyclecheck.cpp
@@ -5,7 +5,7 @@ typedef pair<int, int> ii;
 typedef vector<ii> vii;
 typedef vector<int> vi;
 
-enum { UNVISITED, EXPLORED, VISITED };           // three flags
+enum { UNVISITED = -1, EXPLORED = -2, VISITED = -3 };           // three flags
 
 // these variables have to be global to be easily accessible by our recursion (other ways exist)
 vector<vii> AL;

--- a/ch4/traversal/cyclecheck.py
+++ b/ch4/traversal/cyclecheck.py
@@ -1,0 +1,55 @@
+import sys
+from enum import Enum
+
+class flag(Enum):
+  UNVISITED = 1
+  EXPLORED = 2
+  VISITED = 3
+
+AL = []
+dfs_num = []
+dfs_parent = []
+
+def cycleCheck(u):
+  global AL
+  global dfs_num
+  global dfs_parent
+
+  dfs_num[u] = flag.EXPLORED.value
+  for v, w in AL[u]:
+    if dfs_num[v] == flag.UNVISITED.value:
+      dfs_parent[v] = u
+      cycleCheck(v)
+    elif dfs_num[v] == flag.EXPLORED.value:
+      if v == dfs_parent[u]:
+        printf(' Bidirectional Edge (%d, %d)-(%d, %d)' % (u, v, v, u))
+      else:
+        print('Back Edge (%d, %d) (Cycle)' % (u, v))
+  dfs_num[u] = flag.VISITED.value
+
+
+def main():
+  global AL
+  global dfs_num
+  global dfs_parent
+
+  fp = open('scc_in.txt', 'r')
+
+  V = int(fp.readline().strip())
+  AL = [[] for _ in range(V)]
+  for u in range(V):
+    tkn = list(map(int, fp.readline().strip().split()))
+    k = tkn[0]
+    for i in range(k):
+      v, w = [tkn[2*i+1], tkn[2*i+2]]
+      AL[u].append((v, w))
+
+  print('Graph Edges Property Check')
+  dfs_num = [flag.UNVISITED.value] * V
+  dfs_parent = [-1] * V
+  for u in range(V):
+    if dfs_num[u] == flag.UNVISITED.value:
+      cycleCheck(u)
+
+
+main()

--- a/ch4/traversal/cyclecheck.py
+++ b/ch4/traversal/cyclecheck.py
@@ -2,9 +2,9 @@ import sys
 from enum import Enum
 
 class flag(Enum):
-  UNVISITED = 1
-  EXPLORED = 2
-  VISITED = 3
+  UNVISITED = -1
+  EXPLORED = -2
+  VISITED = -3
 
 AL = []
 dfs_num = []

--- a/ch4/traversal/dfs_cc.cpp
+++ b/ch4/traversal/dfs_cc.cpp
@@ -5,7 +5,7 @@ typedef pair<int, int> ii;
 typedef vector<ii> vii;
 typedef vector<int> vi;
 
-enum { UNVISITED, VISITED };                     // basic flags
+enum { UNVISITED = -1, VISITED = -2 };                     // basic flags
 
 // these variables have to be global to be easily accessible by our recursion (other ways exist)
 vector<vii> AL;

--- a/ch4/traversal/toposort.cpp
+++ b/ch4/traversal/toposort.cpp
@@ -5,7 +5,7 @@ typedef pair<int, int> ii;
 typedef vector<ii> vii;
 typedef vector<int> vi;
 
-enum { UNVISITED, VISITED };                     // basic flags
+enum { UNVISITED = -1, VISITED = -2 };                     // basic flags
 
 // these variables have to be global to be easily accessible by our recursion (other ways exist)
 vector<vii> AL;

--- a/ch4/traversal/toposort.py
+++ b/ch4/traversal/toposort.py
@@ -1,0 +1,49 @@
+import sys
+from enum import Enum
+
+class flag(Enum):
+  UNVISITED = 1
+  VISITED = 2
+
+AL = []
+dfs_num = []
+ts = []
+
+def toposort(u):
+  global AL
+  global dfs_num
+  global ts
+
+  dfs_num[u] = flag.VISITED.value
+  for v, w in AL[u]:
+    if dfs_num[v] == flag.UNVISITED.value:
+      toposort(v)
+  ts.append(u)
+
+
+def main():
+  global AL
+  global dfs_num
+  global ts
+
+  fp = open('toposort_in.txt', 'r')
+
+  V = int(fp.readline().strip())
+  AL = [[] for _ in range(V)]
+  for u in range(V):
+    tkn = list(map(int, fp.readline().strip().split()))
+    k = tkn[0]
+    for i in range(k):
+      v, w = tkn[2*i+1], tkn[2*i+2]
+      AL[u].append((v, w))
+
+  print('Topological Sort (the input graph must be DAG)')
+  dfs_num = [flag.UNVISITED.value] * V
+  for u in range(V):
+    if dfs_num[u] == flag.UNVISITED.value:
+      toposort(u)
+  ts = ts[::-1]
+  print(' '.join(map(str, ts)))
+
+
+main()

--- a/ch4/traversal/toposort.py
+++ b/ch4/traversal/toposort.py
@@ -2,8 +2,8 @@ import sys
 from enum import Enum
 
 class flag(Enum):
-  UNVISITED = 1
-  VISITED = 2
+  UNVISITED = -1
+  VISITED = -2
 
 AL = []
 dfs_num = []


### PR DESCRIPTION
`enum { UNVISITED };` in `articulation.cpp`  has a potential bug as its value is 0; the same value is also used to flag the visit order (and it can be 0).

Solution: assign (negative) values for the `enum`.

Other `enum` in `ch4/traversal/*.cpp` are also fixed even though they might be OK.