### PR TITLE
Fenwick Range Update type fix

### DIFF
--- a/ch2/ourown/fenwicktree_ds.cpp
+++ b/ch2/ourown/fenwicktree_ds.cpp
@@ -67,7 +67,7 @@ private:
   FenwickTree ft;                                // internally use PURQ FT
 public:
   RUPQ(int m) : ft(FenwickTree(m)) {}
-  void range_update(int ui, int uj, int v) {
+  void range_update(int ui, int uj, ll v) {
     ft.update(ui, v);                            // [ui, ui+1, .., m] +v
     ft.update(uj+1, -v);                         // [uj+1, uj+2, .., m] -v
   }                                              // [ui, ui+1, .., uj] +v
@@ -80,7 +80,7 @@ private:                                         // needs two helper FTs
   FenwickTree purq;                              // one PURQ
 public:
   RURQ(int m) : rupq(RUPQ(m)), purq(FenwickTree(m)) {} // initialization
-  void range_update(int ui, int uj, int v) {
+  void range_update(int ui, int uj, ll v) {
     rupq.range_update(ui, uj, v);                // [ui, ui+1, .., uj] +v
     purq.update(ui, v*(ui-1));                   // -(ui-1)*v before ui
     purq.update(uj+1, -v*uj);                    // +(uj-ui+1)*v after uj


### PR DESCRIPTION
The single point update uses the long long type. Therefore, the range updates should use the same type.