### PR TITLE
Fix in Fenwick Tree select's method

### DIFF
--- a/ch2/ourown/fenwicktree_ds.cpp
+++ b/ch2/ourown/fenwicktree_ds.cpp
@@ -52,7 +52,7 @@ public:
     while (p*2 < (int)ft.size()) p *= 2;
     int i = 0;
     while (p) {
-      if (k > ft[i+p]) {
+      if (i+p < (int) ft.size() && k > ft[i+p]) {
         k -= ft[i+p];
         i += p;
       }


### PR DESCRIPTION
The issue was caused by an out of range access.
Tests for this change that run successfully: https://ideone.com/a8go2h.